### PR TITLE
License: Replaces "BSD" with "GPLv3" in package.xml.

### DIFF
--- a/iiwa_control/package.xml
+++ b/iiwa_control/package.xml
@@ -31,7 +31,7 @@
 
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <url type="repository">https://github.com/costashatz/iiwa_ros</url>
   <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>

--- a/iiwa_description/package.xml
+++ b/iiwa_description/package.xml
@@ -31,7 +31,7 @@
   <author email="salvo.virga@tum.de">Salvo Virga</author>
   <maintainer email="salvo.virga@tum.de">Salvo Virga</maintainer>
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/iiwa_driver/package.xml
+++ b/iiwa_driver/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <url type="repository">https://github.com/costashatz/iiwa_ros</url>
   <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>

--- a/iiwa_gazebo/package.xml
+++ b/iiwa_gazebo/package.xml
@@ -30,7 +30,7 @@
   <description>This package allows to load a KUKA LBR IIWA robot onto Gazebo</description>
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <url type="repository">https://github.com/costashatz/iiwa_ros</url>
   <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>

--- a/iiwa_moveit/package.xml
+++ b/iiwa_moveit/package.xml
@@ -33,7 +33,7 @@
   <author email="yoan@aubrune.eu">Yoan Mollard</author>
   <maintainer email="konstantinos.chatzilygeroudis@epfl.ch">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/iiwa_ros/package.xml
+++ b/iiwa_ros/package.xml
@@ -32,7 +32,7 @@
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <url type="repository">https://github.com/costashatz/iiwa_ros</url>
   <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>

--- a/iiwa_tools/package.xml
+++ b/iiwa_tools/package.xml
@@ -30,7 +30,7 @@
   <description>This package creates a few tools as a library and as services (e.g., IK, Jacobian etc.) for the IIWA robot</description>
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>BSD</license>
+  <license>GPLv3</license>
 
   <url type="repository">https://github.com/costashatz/iiwa_ros</url>
   <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>


### PR DESCRIPTION
The repository is clearly GPL-licenced, but the tags in all the package.xml files still contained "BSD".

One might consider to extend the `add_license.py` script as well. This PR allows edits.