### PR TITLE
Fix: Corrects dependencies on iiwa_tools.

### DIFF
--- a/iiwa_control/CMakeLists.txt
+++ b/iiwa_control/CMakeLists.txt
@@ -92,7 +92,7 @@ target_link_libraries(CustomEffortController PUBLIC
   ${Eigen3_LIBRARIES}
   Corrade::PluginManager)
 
-add_dependencies(CustomEffortController iiwa_service)
+add_dependencies(CustomEffortController ${iiwa_tools_EXPORTED_TARGETS})
 
 # Require C++11
 set_property(TARGET CustomEffortController PROPERTY CXX_STANDARD 11)

--- a/iiwa_gazebo/CMakeLists.txt
+++ b/iiwa_gazebo/CMakeLists.txt
@@ -53,7 +53,7 @@ set_property(TARGET iiwa_gazebo_gravity_compensation_hw_sim PROPERTY CXX_STANDAR
 target_include_directories(iiwa_gazebo_gravity_compensation_hw_sim PUBLIC include ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS})
 target_link_libraries(iiwa_gazebo_gravity_compensation_hw_sim PUBLIC ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 
-add_dependencies(iiwa_gazebo_gravity_compensation_hw_sim iiwa_service)
+add_dependencies(iiwa_gazebo_gravity_compensation_hw_sim ${iiwa_tools_EXPORTED_TARGETS})
 
 # Install
 install(TARGETS iiwa_gazebo_gravity_compensation_hw_sim


### PR DESCRIPTION
When building `iiwa_ros` with `catkin tools`, I always need to build twice. `iiwa_service` is not built yet when it tries to build the hardware plugin or the controller.

This is according to [the catkin documentation](http://wiki.ros.org/catkin/CMakeLists.txt#Important_Prerequisites.2FConstraints) and fixes the problem for me.

