### PR TITLE
Feature: Calculate wrench in end effector frame.

### DIFF
--- a/iiwa_tools/include/iiwa_tools/iiwa_tools.h
+++ b/iiwa_tools/include/iiwa_tools/iiwa_tools.h
@@ -59,6 +59,7 @@ namespace iiwa_tools {
         Eigen::MatrixXd jacobian(const RobotState& robot_state);
         Eigen::MatrixXd jacobian_deriv(const RobotState& robot_state);
         std::pair<Eigen::MatrixXd, Eigen::MatrixXd> jacobians(const RobotState& robot_state);
+        Eigen::VectorXd ee_wrench(const RobotState& robot_state, const Eigen::VectorXd ext_torque);
         Eigen::VectorXd gravity(const std::vector<double>& gravity, const RobotState& robot_state);
 
     protected:


### PR DESCRIPTION
I want to put this up for discussion. If there is interest, I can add a service for it.
Things to discuss are:

- relevance for other people
- double-check the math
- pseudo_inverse is only copied, so it appears twice in the code if this PR is not changed
- sign convention: our UR outputs wrench values with opposite sign

I also do have an executable that fetches joint states and external torques and publishes the wrench. I can make this a part of iiwa_tools as well if there is interest.

For reference: #19, #27