### PR TITLE
Feature: Introduces realtime support.

### DIFF
--- a/iiwa_driver/src/iiwa.cpp
+++ b/iiwa_driver/src/iiwa.cpp
@@ -36,14 +36,14 @@
 #include <thread>
 
 namespace iiwa_ros {
-    bool hasRealtimeKernel() {
+    bool has_realtime_kernel() {
         std::ifstream realtime("/sys/kernel/realtime", std::ios_base::in);
         bool is_realtime;
         realtime >> is_realtime;
         return is_realtime;
     }
 
-    bool setCurrentThreadToHighestSchedulerPriority(std::string& error_message) {
+    bool set_thread_to_highest_priority(std::string& error_message) {
         const int thread_priority = sched_get_priority_max(SCHED_FIFO);
         if (thread_priority == -1) {
             if (error_message.empty()) {
@@ -86,9 +86,9 @@ namespace iiwa_ros {
         _commanding_status_pub = _nh.advertise<std_msgs::Bool>("commanding_status", 100);
         _controller_manager.reset(new controller_manager::ControllerManager(this, _nh));
 
-        if (hasRealtimeKernel()) {
+        if (has_realtime_kernel()) {
             std::string error_message;
-            if (!setCurrentThreadToHighestSchedulerPriority(error_message)) {
+            if (!set_thread_to_highest_priority(error_message)) {
                 ROS_ERROR_STREAM(error_message);
             } else {
                 ROS_INFO_STREAM("Initializing with realtime scheduling support.");


### PR DESCRIPTION
I'd put this up for discussion as well.

This follows the suggestions of @JimmyDaSilva as discussed in #36. The new functions are close to the ones in libfranka. I would argue that the code is so generic, that threshold of originality is not met and it can be included here.

It is my first time dealing with a preempt_rt kernel and realtime systems, But I had quite some interruptions when connecting via FRI from some 5 year old laptop with an i7. So I spend a bit of time adding this.
I guess there would be more changes needed to introduce actual realtime support. E.g. make this `commanding_status` publisher realltime compliant. This pull request allows edits.

This patch makes realtime support optional. I guess this would be the way to go for this repository.