### PR TITLE
Update CMake and README to work with SVA/RBDyn/mc_rbdyn_urdf master

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,28 @@ sudo ./waf install
 
 ```sh
 cd /source/directory
-git clone --recursive https://github.com/costashatz/SpaceVecAlg.git
+git clone --recursive https://github.com/jrl-umi3218/SpaceVecAlg.git
 cd SpaceVecAlg
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SIMD=ON -DPYTHON_BINDING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native -faligned-new" -DPYTHON_BINDING=OFF ..
 make -j
 sudo make install
+```
+
+Instead of passing `-DCMAKE_CXX_FLAGS="-march=native -faligned-new"` for `SpaceVecAlg`, `RBDyn` and `mc_rbdyn_urdf` builds you can also set the `CXXFLAGS` environment variables and omit the option:
+
+```sh
+export CXXFLAGS="-march=native -faligned-new"
 ```
 
 ### RBDyn
 
 ```sh
 cd /source/directory
-git clone --recursive https://github.com/costashatz/RBDyn.git
+git clone --recursive https://github.com/jrl-umi3218/RBDyn.git
 cd RBDyn
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SIMD=ON -DPYTHON_BINDING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native -faligned-new" -DPYTHON_BINDING=OFF ..
 make -j
 sudo make install
 ```
@@ -65,10 +71,10 @@ sudo make install
 
 ```sh
 cd /source/directory
-git clone --recursive https://github.com/costashatz/mc_rbdyn_urdf.git
+git clone --recursive https://github.com/jrl-umi3218/mc_rbdyn_urdf.git
 cd mc_rbdyn_urdf
 mkdir build && cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_SIMD=ON -DPYTHON_BINDING=OFF ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-march=native -faligned-new" -DPYTHON_BINDING=OFF ..
 make -j
 sudo make install
 ```
@@ -184,9 +190,9 @@ Authors/Maintainers
 [gazebo]: http://gazebosim.org/
 [ros control]: http://wiki.ros.org/ros_control
 [kuka fri]: https://github.com/costashatz/kuka_fri
-[spacevecalg]: https://github.com/costashatz/SpaceVecAlg
-[rbdyn]: https://github.com/costashatz/RBDyn
-[mc_rbdyn_urdf]: https://github.com/costashatz/mc_rbdyn_urdf
+[spacevecalg]: https://github.com/jrl-umi3218/SpaceVecAlg
+[rbdyn]: https://github.com/jrl-umi3218/RBDyn
+[mc_rbdyn_urdf]: https://github.com/jrl-umi3218/mc_rbdyn_urdf
 [robot_controllers]: https://github.com/epfl-lasa/robot_controllers
 [corrade]: https://github.com/mosra/corrade
 [iiwa_stack]: https://github.com/IFL-CAMP/iiwa_stack

--- a/iiwa_tools/CMakeLists.txt
+++ b/iiwa_tools/CMakeLists.txt
@@ -29,14 +29,7 @@ option(ENABLE_SIMD "Build with all SIMD instructions on the current local machin
 
 find_package(PkgConfig)
 
-# Find RBDyn library and dependencies
-pkg_search_module(Eigen3 REQUIRED eigen3)
-find_package(Boost 1.49 REQUIRED)
-
-pkg_check_modules(tinyxml2 REQUIRED tinyxml2)
-pkg_check_modules(SpaceVecAlg REQUIRED SpaceVecAlg)
-pkg_check_modules(RBDyn REQUIRED RBDyn)
-pkg_check_modules(mc_rbdyn_urdf REQUIRED mc_rbdyn_urdf)
+find_package(mc_rbdyn_urdf REQUIRED)
 
 # Find catkin components
 find_package(catkin REQUIRED COMPONENTS
@@ -66,14 +59,13 @@ generate_messages(
 catkin_package(
  INCLUDE_DIRS include
  CATKIN_DEPENDS roscpp message_runtime std_msgs sensor_msgs geometry_msgs
- DEPENDS Boost tinyxml2 SpaceVecAlg RBDyn mc_rbdyn_urdf
  LIBRARIES iiwa_tools
 )
 
 add_library(iiwa_tools SHARED src/iiwa_tools.cpp)
 target_compile_options(iiwa_tools PUBLIC -std=c++11)
-target_include_directories(iiwa_tools PUBLIC include ${catkin_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${tinyxml2_INCLUDE_DIRS} ${SpaceVecAlg_INCLUDE_DIRS} ${RBDyn_INCLUDE_DIRS} ${mc_rbdyn_urdf_INCLUDE_DIRS})
-target_link_libraries(iiwa_tools PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${tinyxml2_LIBRARIES} ${SpaceVecAlg_LIBRARIES} ${RBDyn_LIBRARIES} ${mc_rbdyn_urdf_LIBRARIES})
+target_include_directories(iiwa_tools PUBLIC include ${catkin_INCLUDE_DIRS})
+target_link_libraries(iiwa_tools PUBLIC ${catkin_LIBRARIES} mc_rbdyn_urdf::mc_rbdyn_urdf)
 
 add_executable(iiwa_service src/iiwa_service.cpp src/iiwa_service_node.cpp)
 
@@ -95,8 +87,8 @@ if(ENABLE_SIMD)
 endif()
 
 target_compile_options(iiwa_service PUBLIC -std=c++11)
-target_include_directories(iiwa_service PUBLIC include ${catkin_INCLUDE_DIRS} ${Eigen3_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${tinyxml2_INCLUDE_DIRS} ${SpaceVecAlg_INCLUDE_DIRS} ${RBDyn_INCLUDE_DIRS} ${mc_rbdyn_urdf_INCLUDE_DIRS})
-target_link_libraries(iiwa_service PUBLIC ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${tinyxml2_LIBRARIES} ${SpaceVecAlg_LIBRARIES} ${RBDyn_LIBRARIES} ${mc_rbdyn_urdf_LIBRARIES} iiwa_tools)
+target_include_directories(iiwa_service PUBLIC include ${catkin_INCLUDE_DIRS})
+target_link_libraries(iiwa_service PUBLIC ${catkin_LIBRARIES} iiwa_tools)
 
 add_dependencies(iiwa_service iiwa_tools_generate_messages_cpp)
 


### PR DESCRIPTION
This PR updates the CMake script and the instruction to build the stack with up-to-date SpaceVecAlg, RBDyn and mc_rbdyn_urdf

Depending on how things go with https://github.com/jrl-umi3218/SpaceVecAlg/pull/29 we can amend the instructions