### PR TITLE
Chore: Removes iiwa_hw from this project

### DIFF
--- a/iiwa_moveit/launch/moveit_planning_execution.launch
+++ b/iiwa_moveit/launch/moveit_planning_execution.launch
@@ -65,12 +65,6 @@
             <arg name="robot_name" value="$(arg robot_name)" />
             <arg name="model" value="$(arg model)" />
         </include>
-
-        <!-- Robot interface -->
-        <include file="$(find iiwa_hw)/launch/iiwa_hw.launch" >
-            <arg name="hardware_interface" value="$(arg hardware_interface)" />
-        </include>
-
     </group>
 
     <!-- Load move_group -->

--- a/iiwa_moveit/package.xml
+++ b/iiwa_moveit/package.xml
@@ -55,6 +55,5 @@
   <depend>robot_state_publisher</depend>
   <depend>xacro</depend>
   <depend>iiwa_description</depend>
-  <depend>iiwa_hw</depend>
 
 </package>


### PR DESCRIPTION
`iiwa_hw` does not exist in this project. The references probably [came from iiwa_stack](https://github.com/IFL-CAMP/iiwa_stack/blob/master/iiwa_hw/package.xml)

It definitely needs to go in the `package.xml`. The references there always breaks `rosdep` for me since it can not resolve for the non-existent `iiwa_hw`.

I was wondering a bit about the MoveIt configuration since that one should also break. Maybe it's just not used a lot?
We have our own one in any case.