### PR TITLE
New: Calculate elapsed time in ctrl_loop

### DIFF
--- a/iiwa_driver/include/iiwa_driver/iiwa.h
+++ b/iiwa_driver/include/iiwa_driver/iiwa.h
@@ -87,8 +87,8 @@ namespace iiwa_ros {
         void _init();
         void _ctrl_loop();
         void _load_params();
-        void _read(ros::Duration elapsed_time);
-        void _write(ros::Duration elapsed_time);
+        void _read(const ros::Duration& ctrl_duration);
+        void _write(const ros::Duration& ctrl_duration);
         bool _init_fri();
         bool _connect_fri();
         void _disconnect_fri();


### PR DESCRIPTION
- ros_control expects the actual time difference in the update call
- I did not use the actually measured time in safety checks and velocity calculation yet. I was not brave enough to enable that. Also if there are FRI interruptions, this value can become seconds.
- ros::Time::now() is not realtime safe. However realtime_tools' clock limited to 750Hz right now: https://github.com/ros-controls/realtime_tools/issues/23

Here are some measurements of the elapsed time (wrongly labelled "ctrl_duration" in the plot) running a 1 kHz FRI connection (#90) together with [this Cartesian impedance controller](https://github.com/matthias-mayr/Cartesian-Impedance-Controller):
![image](https://user-images.githubusercontent.com/64466074/203655361-a9b6b96e-4cda-402c-9c07-b5191bb81d65.png)
(Green and blue (covered by green) are the controller calculations)