### PR TITLE
New: Make it optional to publish extra data

### DIFF
--- a/iiwa_driver/CMakeLists.txt
+++ b/iiwa_driver/CMakeLists.txt
@@ -51,6 +51,8 @@ find_package(FRI REQUIRED COMPONENTS
 add_message_files(
   FILES
   AdditionalOutputs.msg
+  ConnectionQuality.msg
+  FRIState.msg
 )
 
 generate_messages(

--- a/iiwa_driver/config/iiwa.yaml
+++ b/iiwa_driver/config/iiwa.yaml
@@ -13,3 +13,7 @@ hardware_interface:
     - iiwa_joint_5
     - iiwa_joint_6
     - iiwa_joint_7
+
+publish:
+  additional_info: true
+  commanded_torques: true

--- a/iiwa_driver/include/iiwa_driver/iiwa.h
+++ b/iiwa_driver/include/iiwa_driver/iiwa.h
@@ -32,8 +32,9 @@
 #include <realtime_tools/realtime_publisher.h>
 
 #include <iiwa_driver/AdditionalOutputs.h>
-#include <std_msgs/Float64MultiArray.h>
+#include <iiwa_driver/FRIState.h>
 #include <std_msgs/Bool.h>
+#include <std_msgs/Float64MultiArray.h>
 
 #include <hardware_interface/joint_command_interface.h>
 #include <hardware_interface/joint_state_interface.h>
@@ -99,6 +100,7 @@ namespace iiwa_ros {
 
         // External torque and commanding status publishers
         realtime_tools::RealtimePublisher<iiwa_driver::AdditionalOutputs> _additional_pub;
+        realtime_tools::RealtimePublisher<iiwa_driver::FRIState> _fri_state_pub;
         realtime_tools::RealtimePublisher<std_msgs::Bool> _commanding_status_pub;
 
         // Interfaces

--- a/iiwa_driver/include/iiwa_driver/iiwa.h
+++ b/iiwa_driver/include/iiwa_driver/iiwa.h
@@ -146,6 +146,8 @@ namespace iiwa_ros {
         ros::Duration _control_period;
         double _control_freq;
         bool _initialized;
+        bool _publish_additional_info{false};
+        bool _publish_commanding_status{false};
     };
 } // namespace iiwa_ros
 

--- a/iiwa_driver/msg/ConnectionQuality.msg
+++ b/iiwa_driver/msg/ConnectionQuality.msg
@@ -1,0 +1,5 @@
+int8 connection_quality
+int8 POOR = 0       # poor connection quality
+int8 FAIR = 1       # connection quality insufficient for command mode
+int8 GOOD = 2       # connection quality sufficient for command mode
+int8 EXCELLENT = 3  # excellent connection quality

--- a/iiwa_driver/msg/FRIState.msg
+++ b/iiwa_driver/msg/FRIState.msg
@@ -1,0 +1,3 @@
+Header header
+
+ConnectionQuality connection_quality

--- a/iiwa_driver/src/iiwa.cpp
+++ b/iiwa_driver/src/iiwa.cpp
@@ -224,24 +224,28 @@ namespace iiwa_ros {
         registerInterface(&_effort_joint_interface);
         registerInterface(&_velocity_joint_interface);
 
-        _commanding_status_pub.init(_nh, "commanding_status", 100);
+        if (_publish_commanding_status) {
+            _commanding_status_pub.init(_nh, "commanding_status", 100);
+        }
 
-        _additional_pub.init(_nh, "additional_outputs", 20);
-        _additional_pub.msg_.external_torques.layout.dim.resize(1);
-        _additional_pub.msg_.external_torques.layout.data_offset = 0;
-        _additional_pub.msg_.external_torques.layout.dim[0].size = _num_joints;
-        _additional_pub.msg_.external_torques.layout.dim[0].stride = 0;
-        _additional_pub.msg_.external_torques.data.resize(_num_joints);
-        _additional_pub.msg_.commanded_torques.layout.dim.resize(1);
-        _additional_pub.msg_.commanded_torques.layout.data_offset = 0;
-        _additional_pub.msg_.commanded_torques.layout.dim[0].size = _num_joints;
-        _additional_pub.msg_.commanded_torques.layout.dim[0].stride = 0;
-        _additional_pub.msg_.commanded_torques.data.resize(_num_joints);
-        _additional_pub.msg_.commanded_positions.layout.dim.resize(1);
-        _additional_pub.msg_.commanded_positions.layout.data_offset = 0;
-        _additional_pub.msg_.commanded_positions.layout.dim[0].size = _num_joints;
-        _additional_pub.msg_.commanded_positions.layout.dim[0].stride = 0;
-        _additional_pub.msg_.commanded_positions.data.resize(_num_joints);
+        if (_publish_additional_info) {
+            _additional_pub.init(_nh, "additional_outputs", 20);
+            _additional_pub.msg_.external_torques.layout.dim.resize(1);
+            _additional_pub.msg_.external_torques.layout.data_offset = 0;
+            _additional_pub.msg_.external_torques.layout.dim[0].size = _num_joints;
+            _additional_pub.msg_.external_torques.layout.dim[0].stride = 0;
+            _additional_pub.msg_.external_torques.data.resize(_num_joints);
+            _additional_pub.msg_.commanded_torques.layout.dim.resize(1);
+            _additional_pub.msg_.commanded_torques.layout.data_offset = 0;
+            _additional_pub.msg_.commanded_torques.layout.dim[0].size = _num_joints;
+            _additional_pub.msg_.commanded_torques.layout.dim[0].stride = 0;
+            _additional_pub.msg_.commanded_torques.data.resize(_num_joints);
+            _additional_pub.msg_.commanded_positions.layout.dim.resize(1);
+            _additional_pub.msg_.commanded_positions.layout.data_offset = 0;
+            _additional_pub.msg_.commanded_positions.layout.dim[0].size = _num_joints;
+            _additional_pub.msg_.commanded_positions.layout.dim[0].stride = 0;
+            _additional_pub.msg_.commanded_positions.data.resize(_num_joints);
+        }
     }
 
     void Iiwa::_ctrl_loop()
@@ -263,13 +267,13 @@ namespace iiwa_ros {
     void Iiwa::_publish()
     {
         // publish commanding status
-        if (_commanding_status_pub.trylock()) {
+        if (_publish_commanding_status && _commanding_status_pub.trylock()) {
             _commanding_status_pub.msg_.data = _commanding;
             _commanding_status_pub.unlockAndPublish();
         }
 
         // publish additional outputs
-        if (_additional_pub.trylock()) {
+        if (_publish_additional_info && _additional_pub.trylock()) {
             _additional_pub.msg_.header.stamp = ros::Time::now();
             for (unsigned i = 0; i < _num_joints; i++) {
                 _additional_pub.msg_.external_torques.data[i] = _robot_state.getExternalTorque()[i];
@@ -290,6 +294,9 @@ namespace iiwa_ros {
 
         n_p.param("hardware_interface/control_freq", _control_freq, 200.);
         n_p.getParam("hardware_interface/joints", _joint_names);
+
+        n_p.param("publish/additional_info", _publish_additional_info, true);
+        n_p.param("publish/commanded_torques", _publish_commanding_status, true);
     }
 
     void Iiwa::_read(ros::Duration elapsed_time)


### PR DESCRIPTION
When working our way up to 1 kHz one factor that could easily break the connection was to send messages - even though they were send by the realtime publisher. The working assumption is that it was due to the network stack.

This PR makes publishing extra data optional in case one does not need it.

In our fork we also have a publisher for the FRI status that can be quite handy when having issues. Should I include that one here as well?