### PR TITLE
New: Sets "Release" build type if none is specified

### DIFF
--- a/iiwa_driver/CMakeLists.txt
+++ b/iiwa_driver/CMakeLists.txt
@@ -61,6 +61,11 @@ generate_messages(
 # Needed for ros packages
 catkin_package(CATKIN_DEPENDS roscpp message_runtime geometry_msgs tf std_msgs sensor_msgs hardware_interface controller_manager urdf realtime_tools)
 
+# Sets build type to "Release" in case no build type has not been set before
+if(NOT CMAKE_BUILD_TYPE) 
+    set(CMAKE_BUILD_TYPE Release)
+endif(NOT CMAKE_BUILD_TYPE)
+
 add_executable(iiwa_driver src/iiwa.cpp src/iiwa_driver.cpp)
 
 # Require C++11


### PR DESCRIPTION
Last PR for today:

catkin workspaces do not define a build type by default. This means that no compiler optimizations are enabled. These lines set the build type if the user did not specify one.

At least in the driver this should be enabled. I checked with our RT-kernel i5 setup and a 1 kHz connection and this PR was not strictly necessary. At least it did maintain a connection for a minute. However it's one step in the right direction and might help some other people.