### PR TITLE
Docs: Improves MoveIt startup docs for simulation

### DIFF
--- a/iiwa_moveit/README.md
+++ b/iiwa_moveit/README.md
@@ -1,8 +1,15 @@
 # IIWA MoveIt package
 
-Starting the MoveIt package requires that you have first setup your robot and environment as specified in the main [README](/README.md#ros-stack-for-kukas-iiwa-robots).
+Starting the MoveIt package requires that you have first setup your robot and environment as specified in the main [README](/README.md).
 
-It can then be started on a real robot by activating the `driver:=true` option:
+In simulation this is launched in two shells as follows:
+```sh
+roslaunch iiwa_gazebo iiwa_gazebo.launch controller:=PositionTrajectoryController
+
+roslaunch iiwa_moveit demo.launch
+```
+
+Alternatively it can then be started on a real robot by activating the `driver:=true` option:
 ```sh
 roslaunch iiwa_moveit demo.launch driver:=true
 ```


### PR DESCRIPTION
Previously users had to figure out themselves to use the `PositionTrajectoryController`