### PR TITLE
Chore: Makes license in package.xml SPDX compliant

### DIFF
--- a/iiwa_control/package.xml
+++ b/iiwa_control/package.xml
@@ -32,10 +32,10 @@
 
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
-  <url type="repository">https://github.com/costashatz/iiwa_ros</url>
-  <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>
+  <url type="repository">https://github.com/epfl-lasa/iiwa_ros</url>
+  <url type="bugtracker">https://github.com/epfl-lasa/iiwa_ros/issues</url>
 
   <author email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</author>
 

--- a/iiwa_description/package.xml
+++ b/iiwa_description/package.xml
@@ -32,7 +32,7 @@
   <author email="salvo.virga@tum.de">Salvo Virga</author>
   <maintainer email="salvo.virga@tum.de">Salvo Virga</maintainer>
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/iiwa_driver/package.xml
+++ b/iiwa_driver/package.xml
@@ -33,10 +33,10 @@
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
-  <url type="repository">https://github.com/costashatz/iiwa_ros</url>
-  <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>
+  <url type="repository">https://github.com/epfl-lasa/iiwa_ros</url>
+  <url type="bugtracker">https://github.com/epfl-lasa/iiwa_ros/issues</url>
 
   <author email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</author>
 

--- a/iiwa_gazebo/package.xml
+++ b/iiwa_gazebo/package.xml
@@ -31,10 +31,10 @@
   <description>This package allows to load a KUKA LBR IIWA robot onto Gazebo</description>
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
-  <url type="repository">https://github.com/costashatz/iiwa_ros</url>
-  <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>
+  <url type="repository">https://github.com/epfl-lasa/iiwa_ros</url>
+  <url type="bugtracker">https://github.com/epfl-lasa/iiwa_ros/issues</url>
 
   <author email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</author>
 

--- a/iiwa_moveit/package.xml
+++ b/iiwa_moveit/package.xml
@@ -34,7 +34,7 @@
   <author email="yoan@aubrune.eu">Yoan Mollard</author>
   <maintainer email="konstantinos.chatzilygeroudis@epfl.ch">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/iiwa_ros/package.xml
+++ b/iiwa_ros/package.xml
@@ -33,10 +33,10 @@
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
-  <url type="repository">https://github.com/costashatz/iiwa_ros</url>
-  <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>
+  <url type="repository">https://github.com/epfl-lasa/iiwa_ros</url>
+  <url type="bugtracker">https://github.com/epfl-lasa/iiwa_ros/issues</url>
 
   <author email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</author>
   

--- a/iiwa_tools/package.xml
+++ b/iiwa_tools/package.xml
@@ -31,10 +31,10 @@
   <description>This package creates a few tools as a library and as services (e.g., IK, Jacobian etc.) for the IIWA robot</description>
   <maintainer email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</maintainer>
 
-  <license>GPLv3</license>
+  <license>GPL-3.0-or-later</license>
 
-  <url type="repository">https://github.com/costashatz/iiwa_ros</url>
-  <url type="bugtracker">https://github.com/costashatz/iiwa_ros/issues</url>
+  <url type="repository">https://github.com/epfl-lasa/iiwa_ros</url>
+  <url type="bugtracker">https://github.com/epfl-lasa/iiwa_ros/issues</url>
 
   <author email="costashatz@gmail.com">Konstantinos Chatzilygeroudis</author>
 


### PR DESCRIPTION
I ran the "ros_license_toolkit" against the repo and this is what it complained about.  
While being in the files, I also updated the repo URL.

The toolkit also complains about the text in the `LICENSE` file of the repo being GPLv3-only and not "and later", but I can not see a difference in the text.  
I opened an issue though: https://github.com/boschresearch/ros_license_toolkit/issues/44